### PR TITLE
Docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,3 +119,5 @@ It was inspired by *dsa-tests*, written by Andrew Lunn.
 == Resources
 
 * link:https://github.com/d-k-c/dsatest[Git source repository on GitHub]
+
+* link:docs/dsatest.1.adoc[`dsatest` man(ual) page]

--- a/README.adoc
+++ b/README.adoc
@@ -56,75 +56,9 @@ bench::
 Describe how the host machine and the target machine are connected to one another.
 This file is specific to each bench.
 
-==== Switch
+NOTE: Take a look at the link:docs/conf-example.adoc[example] in the documentation for a complete test bench.
 
-*TODO: Not used yet*
 
-An example switch may look like this:
-
-----
-  +----------------+
-  |          port0 |----> CPU port
-  | SWITCH   port1 |----> User port #0
-  |          port2 |----> User port #1
-  |          port3 |----> User port #2
-  +----------------+
-----
-
-See link:conf/switch/example-switch.cfg[].
-
-==== Target
-
-They describe the hardware of the machine being tested.
-For instance, consider the following situation:
-
-----
-  +--------------------------------------------------+
-  |                       TARGET                     |
-  |  +----------------+                              |
-  |  |          port0 |----> to CPU                  |
-  |  | switch0  port1 |--------------------------[ link0 ] <-+
-  |  |          port2 |----> Non connected           |       |- connectors
-  |  |          port3 |--------------------------[ link1 ] <-+   (eg. RJ45)
-  |  +----------------+                              |
-  +--------------------------------------------------+
-----
-
-Only port1 and port3 of switch0 are connected to front-facing connectors.
-Obviously the bench can only use these two ports to run tests.
-
-Describing the internals of the target (which switch port is connected to what front-facing connector) allows to get sensible error reporting if errors occur.
-Moreover, these files can be shared by people using the same hardware.
-
-See link:conf/target/example-target.cfg[].
-
-==== Bench
-
-Describe the test bench, i.e. how the controlling machine (aka host), running dsatest, is connected to the target machine.
-
-For instance, let's create a test bench with the target defined in the previous section.
-Host and Target are connected with only one cable:
-
-----
-  +-------------+                        +---------------+
-  |             |         cable          |               |
-  |          [ eth8 ]<------------>[ enp0s31f6 ]         |
-  |   TARGET    |         link0          |               |
-  |          [ eth9 ]                    |      HOST     |
-  |             |                        |               |
-  +-------------+                        +---------------+
-----
-
-Bench configuration file defines that link0 is eth8 on the target side, and enp0s31f6 on host side.
-eth9 is left disconnected.
-Names of interfaces is defined at the bench level because interfaces may have different names depending on the OS running on it, so it may vary from one test bench to another.
-
-See link:bench.cfg.example[].
-
-When a link is defined under both the host and the target section, dsatest will register that link and the corresponding interfaces so that tests will be able to use them.
-Links connected to only one end will be ignored.
-
-==== Configuring the bench
 
 Copy the example bench configuration file and describe your links and how to control your target.
 You may have to provide configuration files for your target and switch(es) if they don't exist yet.

--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,7 @@ target::
 Describe the machine being tested, the switches that are on it, and the interfaces that the test bench will be able to use.
 This file can also be shared.
 They are located in the `target/` configuration directory.
+See the link:docs/conf-target.adoc[target] documentation.
 
 bench::
 Describe how the host machine and the target machine are connected to one another.

--- a/README.adoc
+++ b/README.adoc
@@ -57,6 +57,7 @@ See the link:docs/conf-target.adoc[target] documentation.
 bench::
 Describe how the host machine and the target machine are connected to one another.
 This file is specific to each bench.
+See the link:docs/conf-bench.adoc[bench] documentation.
 
 NOTE: Take a look at the link:docs/conf-example.adoc[example] in the documentation for a complete test bench.
 

--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,7 @@ switch::
 Describe a switch and how its kernel driver exposes some information.
 This file can be shared and used in several test benches.
 They are located in the `switch/` configuration directory.
+See the link:docs/conf-switch.adoc[switch] documentation.
 
 target::
 Describe the machine being tested, the switches that are on it, and the interfaces that the test bench will be able to use.

--- a/README.adoc
+++ b/README.adoc
@@ -1,38 +1,62 @@
-= dsatest
+= Distributed Switch Architecture testing
 
-A test runner for DSA
+dsatest is a Linux user space network testing framework for Ethernet switches driven by the kernel space DSA framework.
+It provides an extensive list of test cases, a command line to access the test bench and run the tests, as well as a Python API.
+It supports many Ethernet switch chips and target machines.
 
+== Getting started
 
-== Usage
+These instructions will get you a copy of the project up and running on your local test bench.
+
+=== Prerequisites
+
+The framework depends on `python` and `python-paramiko`.
+
+=== Installing
+
+To get the source code of the dsatest framework, follow these steps:
 
 [source,sh]
 ----
-# run all tests containing "ping" in their test method names
-./dsatest -t ping -B bench.cfg.example
-
-# run all tests defined in sanity.py, using bench.cfg.example for configuration
-# --dry-run will skip the SSH connection step. This is used for self-testing.
-./dsatest --dry-run -t sanity.py -B bench.cfg.example
+git clone git@github.com:d-k-c/dsatest.git
+cd dsatest/
 ----
 
+Ensure that the framework is functional by listing the tests and running the sanity tests:
 
-== Configuration files
+[source,sh]
+----
+./dsatest -l -B bench.cfg.example
+./dsatest --dry-run -t sanity -B bench.cfg.example
+----
 
+=== Configuring
+
+Configuration files are usually found in the `conf/` directory provided with the dsatest package.
+
+One can use out-of-tree configuration files by using the `-C` or `--conf-dir` flags from the command line.
+The specified directory must have the same layout as the default `conf/` directory.
+Files found in this alternate directory will have precedence over the default ones.
+
+All configuration files use the INI format.
 Three kind of files need to be populated in order to run tests on the bench.
 From a bottom-up approach:
 
-Switch::
-describe a switch and how its kernel driver exposes some information. This file 
-can be shared and used in several test benches.
-Target::
-describe the machine being tested, the switches that are on it, and the 
-interfaces that the test bench will be able to use. This file can also be 
-shared.
-Bench::
-describe how the host machine and the target machine are connected to one 
-another. This file is specific to each bench.
+switch::
+Describe a switch and how its kernel driver exposes some information.
+This file can be shared and used in several test benches.
+They are located in the `switch/` configuration directory.
 
-=== Switch
+target::
+Describe the machine being tested, the switches that are on it, and the interfaces that the test bench will be able to use.
+This file can also be shared.
+They are located in the `target/` configuration directory.
+
+bench::
+Describe how the host machine and the target machine are connected to one another.
+This file is specific to each bench.
+
+==== Switch
 
 *TODO: Not used yet*
 
@@ -49,10 +73,10 @@ An example switch may look like this:
 
 See link:conf/switch/example-switch.cfg[].
 
-=== Target
+==== Target
 
-They are located in `conf/target`. They describe the hardware of the
-machine being tested. For instance, consider the following situation:
+They describe the hardware of the machine being tested.
+For instance, consider the following situation:
 
 ----
   +--------------------------------------------------+
@@ -67,21 +91,19 @@ machine being tested. For instance, consider the following situation:
 ----
 
 Only port1 and port3 of switch0 are connected to front-facing connectors.
-Obviously the bench can only used these two ports to run tests.
+Obviously the bench can only use these two ports to run tests.
 
-Describing the internals of the target (which switch port is connected to what
-front-facing connector) allows to get sensible error reporting if errors occur.
+Describing the internals of the target (which switch port is connected to what front-facing connector) allows to get sensible error reporting if errors occur.
 Moreover, these files can be shared by people using the same hardware.
 
 See link:conf/target/example-target.cfg[].
 
-=== Bench
+==== Bench
 
-Describe the test bench, ie. how the controlling machine (aka host), running
-dsatest, is connect to the target machine.
+Describe the test bench, i.e. how the controlling machine (aka host), running dsatest, is connected to the target machine.
 
-For instance, let's create a test bench with the target defined in the previous
-section. Host and Target are connected with only one cable:
+For instance, let's create a test bench with the target defined in the previous section.
+Host and Target are connected with only one cable:
 
 ----
   +-------------+                        +---------------+
@@ -93,27 +115,54 @@ section. Host and Target are connected with only one cable:
   +-------------+                        +---------------+
 ----
 
-Bench configuration file defines that link0 is eth8 on the target side, and
-enp0s31f6 on host side. eth9 is left disconnected. Names of interfaces is
-defined at the bench level because interfaces may have different names
-depending on the OS running on it, so it may vary from one test bench to
-another.
+Bench configuration file defines that link0 is eth8 on the target side, and enp0s31f6 on host side.
+eth9 is left disconnected.
+Names of interfaces is defined at the bench level because interfaces may have different names depending on the OS running on it, so it may vary from one test bench to another.
 
 See link:bench.cfg.example[].
 
-When a link is defined under both the host and the target section, dsatest will
-register that link and the corresponding interfaces so that tests will be able
-to use them. Links connected to only one end will be ignored.
+When a link is defined under both the host and the target section, dsatest will register that link and the corresponding interfaces so that tests will be able to use them.
+Links connected to only one end will be ignored.
 
-=== Out-of-tree configuration
+==== Configuring the bench
 
-One can use out-of-tree configuration files by using the `-C` or `--conf-dir`
-flags and specifying a directory that has the same layout as the `conf/`
-directory. Files found in this alternate directory will have precedence over the
-ones found in dsatest's `conf` directory.
+Copy the example bench configuration file and describe your links and how to control your target.
+You may have to provide configuration files for your target and switch(es) if they don't exist yet.
 
+[source,sh]
+----
+cp bench.cfg.example bench.cfg
+# edit bench.cfg...
+----
 
-== Tests
+== Running the tests
+
+IMPORTANT: You need the `NET_CAP_ADMIN` capability in order to configure network interfaces.
+
+Test cases are usually found in the `tests/` directory provided with the dsatest package.
+
+One can use out-of-tree test files by using the `-T` or `--test-dir` flags from the command line.
+The specified directory must have the same layout as the default `tests/` directory.
+Files found in this alternate directory will have precedence over the default ones.
+
+=== From the command line
+
+By default, the `dsatest` command runs all the tests found in the test directory.
+Run all tests whose method names are prefixed with *test_port_ping*:
+
+[source,sh]
+----
+./dsatest -t port_ping
+----
+
+For details about command line options, see the help message:
+
+[source,sh]
+----
+./dsatest -h
+----
+
+=== From the Python API
 
 Tests are written using unittest, and must respect rules defined by this module.
 They can access the test bench instance through the following import:
@@ -123,4 +172,13 @@ They can access the test bench instance through the following import:
 from dsatest.bench import bench
 ----
 
-API is self-documented in `test/sanity.py`. More documentation welcome!
+API is self-documented in the `sanity.py` test file.
+
+== Authors
+
+dsatest was written by Damien Riegel and other contributors.
+It was inspired by *dsa-tests*, written by Andrew Lunn.
+
+== Resources
+
+* link:https://github.com/d-k-c/dsatest[Git source repository on GitHub]

--- a/README.adoc
+++ b/README.adoc
@@ -1,44 +1,47 @@
-# dsatest
+= dsatest
 
 A test runner for DSA
 
 
-## Usage
+== Usage
 
-```sh
+[source,sh]
+----
 # run all tests containing "ping" in their test method names
 ./dsatest -t ping -B bench.cfg.example
 
 # run all tests defined in sanity.py, using bench.cfg.example for configuration
 # --dry-run will skip the SSH connection step. This is used for self-testing.
 ./dsatest --dry-run -t sanity.py -B bench.cfg.example
-```
+----
 
 
-## Configuration files
+== Configuration files
 
 Three kind of files need to be populated in order to run tests on the bench.
 From a bottom-up approach:
 
- * Switch: describe a switch and how its kernel driver exposes some
-           information. This file can be shared and used in several test
-           benches.
- * Target: describe the machine being tested, the switches that are on it, and
-           the interfaces that the test bench will be able to use. This file
-           can also be shared.
- * Bench: describe how the host machine and the target machine are connected to
-          one another. This file is specific to each bench.
+Switch::
+describe a switch and how its kernel driver exposes some information. This file 
+can be shared and used in several test benches.
+Target::
+describe the machine being tested, the switches that are on it, and the 
+interfaces that the test bench will be able to use. This file can also be 
+shared.
+Bench::
+describe how the host machine and the target machine are connected to one 
+another. This file is specific to each bench.
 
-### Switch
+=== Switch
 
 *TODO: Not used yet*
 
-### Target
+=== Target
 
 They are located in `conf/target`. They describe the hardware of the
 machine being tested. For instance, consider the following situation:
 
-```
+----
   +--------------------------------------------------+
   |                           Target                 |
   |  +----------------+                              |
@@ -48,7 +51,7 @@ machine being tested. For instance, consider the following situation:
   |  |          port3 |--------------------------[ link1 ] <-+   (eg. RJ45)
   |  +----------------+                              |
   +--------------------------------------------------+
-```
+----
 
 Only port1 and port3 of switch0 are connected to front-facing connectors.
 Obviously the bench can only used these two ports to run tests.
@@ -57,17 +60,16 @@ Describing the internals of the target (which switch port is connected to what
 front-facing connector) allows to get sensible error reporting if errors occur.
 Moreover, these files can be shared by people using the same hardware.
 
-```
-conf/target/target-example.cfg
-----------------------------
-
+.conf/target/target-example.cfg
+[source,ini]
+----
 [switch0]
 name = wag200g
 port1 = link0
 port3 = link1
-```
+----
 
-### Bench
+=== Bench
 
 Describe the test bench, ie. how the controlling machine (aka host), running
 dsatest, is connect to the target machine.
@@ -75,7 +77,7 @@ dsatest, is connect to the target machine.
 For instance, let's create a test bench with the target defined in the previous
 section. Host and Target are connected with only one cable:
 
-```
+----
   +-------------+                        +---------------+
   |             |         cable          |               |
   |          [ eth8 ]<------------>[ enp0s31f6 ]         |
@@ -83,7 +85,7 @@ section. Host and Target are connected with only one cable:
   |          [ eth9 ]                    |      HOST     |
   |             |                        |               |
   +-------------+                        +---------------+
-```
+----
 
 Bench configuration file defines that link0 is eth8 on the target side, and
 enp0s31f6 on host side. eth9 is left disconnected. Names of interfaces is
@@ -92,10 +94,9 @@ depending on the OS running on it, so it may vary from one test bench to
 another.
 
 
-```
-bench.cfg
----------
-
+.bench.cfg
+[source,ini]
+----
 [host]
 link0 = enp0s31f6
 
@@ -108,13 +109,13 @@ link0 = eth8            ; Because the target is running Buildroot, it
 link1 = eth9            ; can be filled in. dsatest will warn that it is
                         ; connected to only one end and will run tests only
                         ; using link0
-```
+----
 
 When a link is defined under both the host and the target section, dsatest will
 register that link and the corresponding interfaces so that tests will be able
 to use them. Links connected to only one end will be ignored.
 
-### Out-of-tree configuration
+=== Out-of-tree configuration
 
 One can use out-of-tree configuration files by using the `-C` or `--conf-dir`
 flags and specifying a directory that has the same layout as the `conf/`
@@ -122,13 +123,14 @@ directory. Files found in this alternate directory will have precedence over the
 ones found in dsatest's `conf` directory.
 
 
-## Tests
+== Tests
 
 Tests are written using unittest, and must respect rules defined by this module.
 They can access the test bench instance through the following import:
 
-```python
+[source,python]
+----
 from dsatest.bench import bench
-```
+----
 
 API is self-documented in `test/sanity.py`. More documentation welcome!

--- a/README.adoc
+++ b/README.adoc
@@ -46,22 +46,40 @@ switch::
 Describe a switch and how its kernel driver exposes some information.
 This file can be shared and used in several test benches.
 They are located in the `switch/` configuration directory.
+ifdef::env-github[]
 See the link:docs/conf-switch.adoc[switch] documentation.
+endif::env-github[]
 
 target::
 Describe the machine being tested, the switches that are on it, and the interfaces that the test bench will be able to use.
 This file can also be shared.
 They are located in the `target/` configuration directory.
+ifdef::env-github[]
 See the link:docs/conf-target.adoc[target] documentation.
+endif::env-github[]
 
 bench::
 Describe how the host machine and the target machine are connected to one another.
 This file is specific to each bench.
+ifdef::env-github[]
 See the link:docs/conf-bench.adoc[bench] documentation.
 
 NOTE: Take a look at the link:docs/conf-example.adoc[example] in the documentation for a complete test bench.
+endif::env-github[]
 
+ifndef::env-github[]
+:leveloffset: +3
 
+include::docs/conf-switch.adoc[]
+
+include::docs/conf-target.adoc[]
+
+include::docs/conf-bench.adoc[]
+
+:leveloffset: -3
+
+NOTE: Take a look at the link:example.html[example] for a complete test bench.
+endif::env-github[]
 
 Copy the example bench configuration file and describe your links and how to control your target.
 You may have to provide configuration files for your target and switch(es) if they don't exist yet.
@@ -118,6 +136,14 @@ It was inspired by *dsa-tests*, written by Andrew Lunn.
 
 == Resources
 
+* link:https://d-k-c.github.io/dsatest[Project website]
+
 * link:https://github.com/d-k-c/dsatest[Git source repository on GitHub]
 
+ifdef::env-github[]
 * link:docs/dsatest.1.adoc[`dsatest` man(ual) page]
+endif::env-github[]
+
+ifndef::env-github[]
+* link:dsatest.1.html[`dsatest` man(ual) page]
+endif::env-github[]

--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,19 @@ another. This file is specific to each bench.
 
 *TODO: Not used yet*
 
+An example switch may look like this:
+
+----
+  +----------------+
+  |          port0 |----> CPU port
+  | SWITCH   port1 |----> User port #0
+  |          port2 |----> User port #1
+  |          port3 |----> User port #2
+  +----------------+
+----
+
+See link:conf/switch/example-switch.cfg[].
+
 === Target
 
 They are located in `conf/target`. They describe the hardware of the
@@ -43,10 +56,10 @@ machine being tested. For instance, consider the following situation:
 
 ----
   +--------------------------------------------------+
-  |                           Target                 |
+  |                       TARGET                     |
   |  +----------------+                              |
   |  |          port0 |----> to CPU                  |
-  |  | Switch0  port1 |--------------------------[ link0 ] <-+
+  |  | switch0  port1 |--------------------------[ link0 ] <-+
   |  |          port2 |----> Non connected           |       |- connectors
   |  |          port3 |--------------------------[ link1 ] <-+   (eg. RJ45)
   |  +----------------+                              |
@@ -60,14 +73,7 @@ Describing the internals of the target (which switch port is connected to what
 front-facing connector) allows to get sensible error reporting if errors occur.
 Moreover, these files can be shared by people using the same hardware.
 
-.conf/target/target-example.cfg
-[source,ini]
-----
-[switch0]
-name = wag200g
-port1 = link0
-port3 = link1
-----
+See link:conf/target/example-target.cfg[].
 
 === Bench
 
@@ -93,23 +99,7 @@ defined at the bench level because interfaces may have different names
 depending on the OS running on it, so it may vary from one test bench to
 another.
 
-
-.bench.cfg
-[source,ini]
-----
-[host]
-link0 = enp0s31f6
-
-[target]
-control = ssh://192.168.0.116
-name = target-example   ; refer to target configuration file
-link0 = eth8            ; Because the target is running Buildroot, it
-                        ; could be named enp0xxx with a distribution running
-                        ; systemd
-link1 = eth9            ; can be filled in. dsatest will warn that it is
-                        ; connected to only one end and will run tests only
-                        ; using link0
-----
+See link:bench.cfg.example[].
 
 When a link is defined under both the host and the target section, dsatest will
 register that link and the corresponding interfaces so that tests will be able

--- a/bench.cfg.example
+++ b/bench.cfg.example
@@ -1,16 +1,14 @@
 [host]
 link0 = enp0s31f6
-;link1 = enp0s31f7
 
 [target]
+name = example-target
 control = "ssh://localhost"
-;username = username
-;password = password
+;username = root
+;password = admin
 ;keyfile = /home/username/.ssh/id_rsa
 ;system_host_keys = /dev/null ; don't use system host keys
 ; Using telnet
 ;control = "telnet://localhost"
 ;prompt = "#"
-name = linksys-wag200g
 link0 = eth8
-link1 = eth9

--- a/bench.cfg.example
+++ b/bench.cfg.example
@@ -6,7 +6,4 @@ name = example-target
 control = "ssh://localhost"
 ;username = root
 ;password = admin
-; Using telnet
-;control = "telnet://localhost"
-;prompt = "#"
 link0 = eth8

--- a/bench.cfg.example
+++ b/bench.cfg.example
@@ -6,8 +6,6 @@ name = example-target
 control = "ssh://localhost"
 ;username = root
 ;password = admin
-;keyfile = /home/username/.ssh/id_rsa
-;system_host_keys = /dev/null ; don't use system host keys
 ; Using telnet
 ;control = "telnet://localhost"
 ;prompt = "#"

--- a/conf/switch/example-switch.cfg
+++ b/conf/switch/example-switch.cfg
@@ -1,0 +1,2 @@
+[info]
+manufacturer = "Example"

--- a/conf/switch/marvell-88e6060.cfg
+++ b/conf/switch/marvell-88e6060.cfg
@@ -1,2 +1,0 @@
-[info]
-manufacturer = "Marvell"

--- a/conf/target/example-target.cfg
+++ b/conf/target/example-target.cfg
@@ -1,0 +1,6 @@
+[switch0]
+name = example-switch
+;port0 = cpu0
+port1 = link0
+;port2 = unused
+port3 = link1

--- a/conf/target/linksys-wag200g.cfg
+++ b/conf/target/linksys-wag200g.cfg
@@ -1,6 +1,0 @@
-[switch0]
-name = marvell-88e6060
-port0 = link0
-port1 = link1
-port2 = link2
-port3 = link3

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,5 +1,8 @@
 require 'asciidoctor'
 
 task :default do
+  Asciidoctor.convert_file '../README.adoc', safe: :unsafe, to_file: 'index.html', attributes: { 'toc' => 'left' }
+  Asciidoctor.convert_file 'conf-example.adoc', safe: :unsafe, to_file: 'example.html', attributes: { 'toc' => 'top' }
+  Asciidoctor.convert_file 'dsatest.1.adoc', safe: :unsafe, attributes: { 'toc' => 'left' }
   Asciidoctor.convert_file 'dsatest.1.adoc', safe: :unsafe, backend: :manpage
 end

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,0 +1,5 @@
+require 'asciidoctor'
+
+task :default do
+  Asciidoctor.convert_file 'dsatest.1.adoc', safe: :unsafe, backend: :manpage
+end

--- a/docs/conf-bench.adoc
+++ b/docs/conf-bench.adoc
@@ -11,6 +11,7 @@ Several control protocols are available.
 
 * link:control-local.adoc[Local control]
 * link:control-ssh.adoc[SSH control]
+* link:control-telnet.adoc[Telnet control]
 
 A bench running tests on a target machine via SSH is described as follow:
 

--- a/docs/conf-bench.adoc
+++ b/docs/conf-bench.adoc
@@ -9,6 +9,8 @@ The purpose of this configuration file is to describe the names of the host and 
 An optional _control_ key is used to describe how to access a machine in the form of an URI.
 Several control protocols are available.
 
+* link:control-local.adoc[Local control]
+
 A bench running tests on a target machine via SSH is described as follow:
 
 .bench.cfg

--- a/docs/conf-bench.adoc
+++ b/docs/conf-bench.adoc
@@ -1,0 +1,39 @@
+= Bench configuration file
+
+A bench configuration file describes the test bench, i.e. how the controlling machine (aka host), running dsatest, is connected to the target machine.
+
+It must have one section describing the _host_ machine and one section describing the _target_ machine.
+
+The purpose of this configuration file is to describe the names of the host and target interfaces connected on both ends of links.
+
+An optional _control_ key is used to describe how to access a machine in the form of an URI.
+Several control protocols are available.
+
+A bench running tests on a target machine via SSH is described as follow:
+
+.bench.cfg
+[source,ini]
+----
+[host] ; <1>
+link0 = eth1
+link1 = eth2
+link2 = eth3 ; <2>
+link3 = eth4
+
+[target] ; <3>
+name = router ; <4>
+control = "ssh://target" ; <5>
+;username = foo
+;password = bar ; <6>
+link0 = lan0
+link1 = lan1
+link2 = lan2 ; <7>
+link3 = lan3
+----
+<1> Host machine section
+<2> Interface name of a link on host side
+<3> Target machine section
+<4> Refers to a `router.cfg` target configuration file
+<5> Control to access the target machine
+<6> Control specific keys
+<7> Interface name of a link on target side

--- a/docs/conf-bench.adoc
+++ b/docs/conf-bench.adoc
@@ -9,9 +9,11 @@ The purpose of this configuration file is to describe the names of the host and 
 An optional _control_ key is used to describe how to access a machine in the form of an URI.
 Several control protocols are available.
 
-* link:control-local.adoc[Local control]
+ifdef::env-github[]
+* link:control-local.adoc[local control]
 * link:control-ssh.adoc[SSH control]
 * link:control-telnet.adoc[Telnet control]
+endif::env-github[]
 
 A bench running tests on a target machine via SSH is described as follow:
 
@@ -41,3 +43,15 @@ link3 = lan3
 <5> Control to access the target machine
 <6> Control specific keys
 <7> Interface name of a link on target side
+
+ifndef::env-github[]
+:leveloffset: +1
+
+include::control-local.adoc[]
+
+include::control-ssh.adoc[]
+
+include::control-telnet.adoc[]
+
+:leveloffset: -1
+endif::env-github[]

--- a/docs/conf-bench.adoc
+++ b/docs/conf-bench.adoc
@@ -10,6 +10,7 @@ An optional _control_ key is used to describe how to access a machine in the for
 Several control protocols are available.
 
 * link:control-local.adoc[Local control]
+* link:control-ssh.adoc[SSH control]
 
 A bench running tests on a target machine via SSH is described as follow:
 

--- a/docs/conf-example.adoc
+++ b/docs/conf-example.adoc
@@ -1,0 +1,70 @@
+= Example bench
+
+This document describes a complete test bench using a target and Ethernet switch from the *Example* manufacturer.
+The sections below explain the three switch, target and bench configuration files used in this bench.
+
+== The Ethernet switch
+
+A simple 4-port Ethernet switch looks like this:
+
+----
++----------------+
+|          port0 |----> CPU port
+| SWITCH   port1 |----> User port #0
+|          port2 |----> User port #1
+|          port3 |----> User port #2
++----------------+
+----
+
+See the link:../conf/switch/example-switch.cfg[configuration file] describing this switch.
+
+== The target machine
+
+The target describes the hardware of the machine being tested.
+For instance, consider the following situation:
+
+----
++--------------------------------------------------+
+|                       TARGET                     |
+|  +----------------+                              |
+|  |          port0 |----> to CPU                  |
+|  | switch0  port1 |--------------------------[ link0 ] <-+
+|  |          port2 |----> Non connected           |       |- connectors
+|  |          port3 |--------------------------[ link1 ] <-+   (eg. RJ45)
+|  +----------------+                              |
++--------------------------------------------------+
+----
+
+Only port1 and port3 of switch0 are connected to front-facing connectors.
+Obviously the bench can only use these two ports to run tests.
+
+Describing the internals of the target (which switch port is connected to what front-facing connector) allows to get sensible error reporting if errors occur.
+Moreover, these files can be shared by people using the same hardware.
+
+See the link:../conf/target/example-target.cfg[configuration file] describing this target.
+
+== The test bench
+
+The bench describes how the controlling machine (aka host), running dsatest, is connected to the target machine.
+
+For instance, let's create a test bench with the target defined in the previous section.
+Host and Target are connected with only one cable:
+
+----
++-------------+                        +---------------+
+|             |         cable          |               |
+|          [ eth8 ]<------------>[ enp0s31f6 ]         |
+|   TARGET    |         link0          |               |
+|          [ eth9 ]                    |      HOST     |
+|             |                        |               |
++-------------+                        +---------------+
+----
+
+The bench configuration file defines that link0 is eth8 on the target side, and enp0s31f6 on host side.
+eth9 on the target side is left disconnected.
+Names of interfaces is defined at the bench level because interfaces may have different names depending on the OS running on it, so it may vary from one test bench to another.
+
+When a link is defined under both the host and the target section, dsatest will register that link and the corresponding interfaces so that tests will be able to use them.
+Links connected to only one end will be ignored.
+
+See the link:../bench.cfg.example[configuration file] describing this bench.

--- a/docs/conf-example.adoc
+++ b/docs/conf-example.adoc
@@ -16,7 +16,18 @@ A simple 4-port Ethernet switch looks like this:
 +----------------+
 ----
 
+ifdef::env-github[]
 See the link:../conf/switch/example-switch.cfg[configuration file] describing this switch.
+endif::env-github[]
+
+ifndef::env-github[]
+This switch is described as follow:
+
+[source,ini]
+----
+include::../conf/switch/example-switch.cfg[]
+----
+endif::env-github[]
 
 == The target machine
 
@@ -41,7 +52,18 @@ Obviously the bench can only use these two ports to run tests.
 Describing the internals of the target (which switch port is connected to what front-facing connector) allows to get sensible error reporting if errors occur.
 Moreover, these files can be shared by people using the same hardware.
 
+ifdef::env-github[]
 See the link:../conf/target/example-target.cfg[configuration file] describing this target.
+endif::env-github[]
+
+ifndef::env-github[]
+This target is described as follow:
+
+[source,ini]
+----
+include::../conf/target/example-target.cfg[]
+----
+endif::env-github[]
 
 == The test bench
 
@@ -67,4 +89,15 @@ Names of interfaces is defined at the bench level because interfaces may have di
 When a link is defined under both the host and the target section, dsatest will register that link and the corresponding interfaces so that tests will be able to use them.
 Links connected to only one end will be ignored.
 
+ifdef::env-github[]
 See the link:../bench.cfg.example[configuration file] describing this bench.
+endif::env-github[]
+
+ifndef::env-github[]
+This bench is described as follow:
+
+[source,ini]
+----
+include::../bench.cfg.example[]
+----
+endif::env-github[]

--- a/docs/conf-switch.adoc
+++ b/docs/conf-switch.adoc
@@ -1,0 +1,5 @@
+= Switch configuration file
+
+Switch configuration files are located in the `switch/` subdirectory of the configuration directory.
+
+NOTE: Switch configuration files have no properties for the moment.

--- a/docs/conf-target.adoc
+++ b/docs/conf-target.adoc
@@ -1,0 +1,29 @@
+= Target configuration file
+
+Target configuration files are located in the `target/` subdirectory of the configuration directory.
+They describe the hardware of the machine being tested.
+
+It must have one section per switch chip.
+Each indexed switch section must describe the switch model and its enabled links.
+
+A target featuring two interconnected switch chips is described as follow:
+
+.router.cfg
+[source,ini]
+----
+[switch0] ; <1>
+name = "foo-etherswitch" ; <2>
+port0 = link0
+port1 = link1
+port2 = link2
+port3 = link3
+
+[switch1]
+name = "foo-etherswitch"
+port0 = link4
+port1 = link5 ; <3>
+port2 = link6
+----
+<1> Switch section indexed from 0
+<2> Refers to a `foo-etherswitch.cfg` switch configuration file
+<3> Local switch port to global _link_ mapping

--- a/docs/control-local.adoc
+++ b/docs/control-local.adoc
@@ -1,0 +1,4 @@
+= Local control
+
+Run command on the local machine. No configuration key is necessary.
+This is the control used by the host machine, which runs the framework.

--- a/docs/control-ssh.adoc
+++ b/docs/control-ssh.adoc
@@ -1,0 +1,22 @@
+= SSH control
+
+Connects to the target machine via SSH.
+
+This control requires the `ssh://` scheme, followed by a hostname and an optional port number.
+There is no mandatory key.
+Optional _username_, _password_, _keyfile_ and _system_host_keys_ keys can be used.
+
+Here's a portion of a _target_ section using the SSH control:
+
+[source,ini]
+----
+control = "ssh://localhost"
+username = bob ; <1>
+password = Secr3t ; <2>
+keyfile = /home/bob/.ssh/id_rsa ; <3>
+system_host_keys = /dev/null ; Don't use system host keys <4>
+----
+<1> Optional username, defaults to "root"
+<2> Optional password, defaults to empty
+<3> Optional alternative key file to use
+<4> Optional alternative host keys file to use

--- a/docs/control-telnet.adoc
+++ b/docs/control-telnet.adoc
@@ -1,0 +1,18 @@
+= Telnet control
+
+Connects to the target machine via Telnet.
+
+This control requires the `telnet://` scheme, followed by a hostname and an optional port number.
+There is no mandatory key.
+Optional _username_, _password_, and _prompt_ keys can be used.
+
+Here's a portion of a _target_ section using the Telnet control:
+
+[source,ini]
+----
+control = "telnet://localhost"
+username = admin ; <1>
+prompt = "#" ; <2>
+----
+<1> Optional username to use
+<2> Optional prompt to use

--- a/docs/dsatest.1
+++ b/docs/dsatest.1
@@ -1,0 +1,95 @@
+'\" t
+.\"     Title: dsatest
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.6.1
+.\"      Date: 2017-10-12
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "DSATEST" "1" "2017-10-12" "\ \&" "\ \&"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+dsatest \- runs tests on DSA targets
+.SH "SYNOPSIS"
+.sp
+\fBdsatest\fP [\fIOPTION\fP]...
+.SH "DESCRIPTION"
+.sp
+The dsatest(1) command runs tests found by the DSA testing framework on the target described in the provided bench configuration file.
+.SH "OPTIONS"
+.sp
+\fB\-h\fP, \fB\-\-help\fP
+.RS 4
+Show this help message and exit.
+.RE
+.sp
+\fB\-t\fP \fITEST\fP, \fB\-\-test\fP \fITEST\fP
+.RS 4
+Restrict tests to be executed.
+This option can be cumulated.
+.RE
+.sp
+\fB\-\-test\-dir\fP \fITEST_DIR\fP
+.RS 4
+Test directory, defaults to the \fItests\fP directory of the dsatest framework.
+.RE
+.sp
+\fB\-l\fP, \fB\-\-list\fP
+.RS 4
+List tests to be executed.
+If \fB\-t\fP is passed, limit the list to the matching tests.
+.RE
+.sp
+\fB\-B\fP \fIBENCH_FILE\fP, \fB\-\-bench\fP \fIBENCH_FILE\fP
+.RS 4
+Bench configuration file, defaults to \fIbench.cfg\fP.
+.RE
+.sp
+\fB\-C\fP \fICONF_DIR\fP, \fB\-\-conf\-dir\fP \fICONF_DIR\fP
+.RS 4
+Configuration directory, default to the \fIconf\fP directory of the dsatest framework.
+.RE
+.sp
+\fB\-\-dry\-run\fP
+.RS 4
+Skip connection to the test bench (no SSH connection is established).
+.RE
+.sp
+\fB\-v\fP, \fB\-\-verbose\fP
+.RS 4
+Turn the verbose mode on.
+This option is a cumulative, so passing \fB\-vv\fP will increase the log level (up to \fB\-vvv\fP).
+.RE
+.SH "EXIT STATUS"
+.sp
+dsatest(1) returns the number of failed tests.
+A returned value of 0 means success.
+.SH "BUGS"
+.sp
+Refer to the \fBdsatest\fP issue tracker at \c
+.URL "https://github.com/d\-k\-c/dsatest/issues" "" "."
+.SH "AUTHORS"
+.sp
+\fBdsatest\fP was written by Damien Riegel and other contributors.
+It was inspired by \fBdsa\-tests\fP, written by Andrew Lunn.
+.SH "RESOURCES"
+.sp
+\fBProject web site:\fP \c
+.URL "https://github.com/d\-k\-c/dsatest" "" ""
+.sp
+\fBGit source repository on GitHub:\fP \c
+.URL "https://github.com/d\-k\-c/dsatest" "" ""
+.SH "COPYING"
+.sp
+Copyright (C) 2017 Savoir\-faire Linux Inc.
+Free use of this software is granted under the terms of the \fITBD\fP License.

--- a/docs/dsatest.1.adoc
+++ b/docs/dsatest.1.adoc
@@ -1,0 +1,67 @@
+= dsatest(1)
+
+== NAME
+
+dsatest - runs tests on DSA targets
+
+== SYNOPSIS
+
+*dsatest* [_OPTION_]...
+
+== DESCRIPTION
+
+The dsatest(1) command runs tests found by the DSA testing framework on the target described in the provided bench configuration file.
+
+== OPTIONS
+
+*-h*, *--help*::
+Show this help message and exit.
+
+*-t* _TEST_, *--test* _TEST_::
+Restrict tests to be executed.
+This option can be cumulated.
+
+*--test-dir* _TEST_DIR_::
+Test directory, defaults to the _tests_ directory of the dsatest framework.
+
+*-l*, *--list*::
+List tests to be executed.
+If *-t* is passed, limit the list to the matching tests.
+
+*-B* _BENCH_FILE_, *--bench* _BENCH_FILE_::
+Bench configuration file, defaults to _bench.cfg_.
+
+*-C* _CONF_DIR_, *--conf-dir* _CONF_DIR_::
+Configuration directory, default to the _conf_ directory of the dsatest framework.
+
+*--dry-run*::
+Skip connection to the test bench (no SSH connection is established).
+
+*-v*, *--verbose*::
+Turn the verbose mode on.
+This option is a cumulative, so passing *-vv* will increase the log level (up to *-vvv*).
+
+== EXIT STATUS
+
+dsatest(1) returns the number of failed tests.
+A returned value of 0 means success. 
+
+== BUGS
+
+Refer to the *dsatest* issue tracker at https://github.com/d-k-c/dsatest/issues.
+
+== AUTHORS
+
+*dsatest* was written by Damien Riegel and other contributors.
+It was inspired by *dsa-tests*, written by Andrew Lunn.
+
+== RESOURCES
+
+*Project web site:* https://github.com/d-k-c/dsatest
+
+*Git source repository on GitHub:* https://github.com/d-k-c/dsatest
+
+== COPYING
+
+Copyright \(C) 2017 Savoir-faire Linux Inc.
+Free use of this software is granted under the terms of the _TBD_ License.

--- a/docs/dsatest.1.html
+++ b/docs/dsatest.1.html
@@ -1,0 +1,568 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
+<title>dsatest(1)</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Remove comment around @import statement below when using as a custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#content{margin-top:1.25em}
+#content:before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+.sect1{padding-bottom:.625em}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:initial}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot{border-width:1px 0}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]:after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span:before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+</style>
+</head>
+<body class="article toc2 toc-left">
+<div id="header">
+<h1>dsatest(1)</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name">NAME</a></li>
+<li><a href="#_synopsis">SYNOPSIS</a></li>
+<li><a href="#_description">DESCRIPTION</a></li>
+<li><a href="#_options">OPTIONS</a></li>
+<li><a href="#_exit_status">EXIT STATUS</a></li>
+<li><a href="#_bugs">BUGS</a></li>
+<li><a href="#_authors">AUTHORS</a></li>
+<li><a href="#_resources">RESOURCES</a></li>
+<li><a href="#_copying">COPYING</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_name">NAME</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>dsatest - runs tests on DSA targets</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_synopsis">SYNOPSIS</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>dsatest</strong> [<em>OPTION</em>]&#8230;&#8203;</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_description">DESCRIPTION</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The dsatest(1) command runs tests found by the DSA testing framework on the target described in the provided bench configuration file.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_options">OPTIONS</h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>-h</strong>, <strong>--help</strong></dt>
+<dd>
+<p>Show this help message and exit.</p>
+</dd>
+<dt class="hdlist1"><strong>-t</strong> <em>TEST</em>, <strong>--test</strong> <em>TEST</em></dt>
+<dd>
+<p>Restrict tests to be executed.
+This option can be cumulated.</p>
+</dd>
+<dt class="hdlist1"><strong>--test-dir</strong> <em>TEST_DIR</em></dt>
+<dd>
+<p>Test directory, defaults to the <em>tests</em> directory of the dsatest framework.</p>
+</dd>
+<dt class="hdlist1"><strong>-l</strong>, <strong>--list</strong></dt>
+<dd>
+<p>List tests to be executed.
+If <strong>-t</strong> is passed, limit the list to the matching tests.</p>
+</dd>
+<dt class="hdlist1"><strong>-B</strong> <em>BENCH_FILE</em>, <strong>--bench</strong> <em>BENCH_FILE</em></dt>
+<dd>
+<p>Bench configuration file, defaults to <em>bench.cfg</em>.</p>
+</dd>
+<dt class="hdlist1"><strong>-C</strong> <em>CONF_DIR</em>, <strong>--conf-dir</strong> <em>CONF_DIR</em></dt>
+<dd>
+<p>Configuration directory, default to the <em>conf</em> directory of the dsatest framework.</p>
+</dd>
+<dt class="hdlist1"><strong>--dry-run</strong></dt>
+<dd>
+<p>Skip connection to the test bench (no SSH connection is established).</p>
+</dd>
+<dt class="hdlist1"><strong>-v</strong>, <strong>--verbose</strong></dt>
+<dd>
+<p>Turn the verbose mode on.
+This option is a cumulative, so passing <strong>-vv</strong> will increase the log level (up to <strong>-vvv</strong>).</p>
+</dd>
+</dl>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_exit_status">EXIT STATUS</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>dsatest(1) returns the number of failed tests.
+A returned value of 0 means success.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_bugs">BUGS</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Refer to the <strong>dsatest</strong> issue tracker at <a href="https://github.com/d-k-c/dsatest/issues" class="bare">https://github.com/d-k-c/dsatest/issues</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_authors">AUTHORS</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>dsatest</strong> was written by Damien Riegel and other contributors.
+It was inspired by <strong>dsa-tests</strong>, written by Andrew Lunn.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_resources">RESOURCES</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Project web site:</strong> <a href="https://github.com/d-k-c/dsatest" class="bare">https://github.com/d-k-c/dsatest</a></p>
+</div>
+<div class="paragraph">
+<p><strong>Git source repository on GitHub:</strong> <a href="https://github.com/d-k-c/dsatest" class="bare">https://github.com/d-k-c/dsatest</a></p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_copying">COPYING</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Copyright (C) 2017 Savoir-faire Linux Inc.
+Free use of this software is granted under the terms of the <em>TBD</em> License.</p>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2017-10-12 22:20:00 EDT
+</div>
+</div>
+</body>
+</html>

--- a/docs/example.html
+++ b/docs/example.html
@@ -1,0 +1,574 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
+<title>Example bench</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Remove comment around @import statement below when using as a custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#content{margin-top:1.25em}
+#content:before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+.sect1{padding-bottom:.625em}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:initial}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot{border-width:1px 0}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]:after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span:before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+</style>
+</head>
+<body class="article toc2 toc-top">
+<div id="header">
+<h1>Example bench</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_the_ethernet_switch">The Ethernet switch</a></li>
+<li><a href="#_the_target_machine">The target machine</a></li>
+<li><a href="#_the_test_bench">The test bench</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>This document describes a complete test bench using a target and Ethernet switch from the <strong>Example</strong> manufacturer.
+The sections below explain the three switch, target and bench configuration files used in this bench.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_the_ethernet_switch">The Ethernet switch</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>A simple 4-port Ethernet switch looks like this:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>+----------------+
+|          port0 |----&gt; CPU port
+| SWITCH   port1 |----&gt; User port #0
+|          port2 |----&gt; User port #1
+|          port3 |----&gt; User port #2
++----------------+</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This switch is described as follow:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[info]
+manufacturer = "Example"</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_the_target_machine">The target machine</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The target describes the hardware of the machine being tested.
+For instance, consider the following situation:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>+--------------------------------------------------+
+|                       TARGET                     |
+|  +----------------+                              |
+|  |          port0 |----&gt; to CPU                  |
+|  | switch0  port1 |--------------------------[ link0 ] &lt;-+
+|  |          port2 |----&gt; Non connected           |       |- connectors
+|  |          port3 |--------------------------[ link1 ] &lt;-+   (eg. RJ45)
+|  +----------------+                              |
++--------------------------------------------------+</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Only port1 and port3 of switch0 are connected to front-facing connectors.
+Obviously the bench can only use these two ports to run tests.</p>
+</div>
+<div class="paragraph">
+<p>Describing the internals of the target (which switch port is connected to what front-facing connector) allows to get sensible error reporting if errors occur.
+Moreover, these files can be shared by people using the same hardware.</p>
+</div>
+<div class="paragraph">
+<p>This target is described as follow:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[switch0]
+name = example-switch
+;port0 = cpu0
+port1 = link0
+;port2 = unused
+port3 = link1</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_the_test_bench">The test bench</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The bench describes how the controlling machine (aka host), running dsatest, is connected to the target machine.</p>
+</div>
+<div class="paragraph">
+<p>For instance, let&#8217;s create a test bench with the target defined in the previous section.
+Host and Target are connected with only one cable:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>+-------------+                        +---------------+
+|             |         cable          |               |
+|          [ eth8 ]&lt;------------&gt;[ enp0s31f6 ]         |
+|   TARGET    |         link0          |               |
+|          [ eth9 ]                    |      HOST     |
+|             |                        |               |
++-------------+                        +---------------+</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The bench configuration file defines that link0 is eth8 on the target side, and enp0s31f6 on host side.
+eth9 on the target side is left disconnected.
+Names of interfaces is defined at the bench level because interfaces may have different names depending on the OS running on it, so it may vary from one test bench to another.</p>
+</div>
+<div class="paragraph">
+<p>When a link is defined under both the host and the target section, dsatest will register that link and the corresponding interfaces so that tests will be able to use them.
+Links connected to only one end will be ignored.</p>
+</div>
+<div class="paragraph">
+<p>This bench is described as follow:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[host]
+link0 = enp0s31f6
+
+[target]
+name = example-target
+control = "ssh://localhost"
+;username = root
+;password = admin
+link0 = eth8</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2017-10-12 22:20:00 EDT
+</div>
+</div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,853 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
+<title>Distributed Switch Architecture testing</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Remove comment around @import statement below when using as a custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#content{margin-top:1.25em}
+#content:before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+.sect1{padding-bottom:.625em}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:initial}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot{border-width:1px 0}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]:after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span:before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+</style>
+</head>
+<body class="article toc2 toc-left">
+<div id="header">
+<h1>Distributed Switch Architecture testing</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_getting_started">Getting started</a>
+<ul class="sectlevel2">
+<li><a href="#_prerequisites">Prerequisites</a></li>
+<li><a href="#_installing">Installing</a></li>
+<li><a href="#_configuring">Configuring</a></li>
+</ul>
+</li>
+<li><a href="#_running_the_tests">Running the tests</a>
+<ul class="sectlevel2">
+<li><a href="#_from_the_command_line">From the command line</a></li>
+<li><a href="#_from_the_python_api">From the Python API</a></li>
+</ul>
+</li>
+<li><a href="#_authors">Authors</a></li>
+<li><a href="#_resources">Resources</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>dsatest is a Linux user space network testing framework for Ethernet switches driven by the kernel space DSA framework.
+It provides an extensive list of test cases, a command line to access the test bench and run the tests, as well as a Python API.
+It supports many Ethernet switch chips and target machines.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_getting_started">Getting started</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>These instructions will get you a copy of the project up and running on your local test bench.</p>
+</div>
+<div class="sect2">
+<h3 id="_prerequisites">Prerequisites</h3>
+<div class="paragraph">
+<p>The framework depends on <code>python</code> and <code>python-paramiko</code>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_installing">Installing</h3>
+<div class="paragraph">
+<p>To get the source code of the dsatest framework, follow these steps:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sh" data-lang="sh">git clone git@github.com:d-k-c/dsatest.git
+cd dsatest/</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Ensure that the framework is functional by listing the tests and running the sanity tests:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sh" data-lang="sh">./dsatest -l -B bench.cfg.example
+./dsatest --dry-run -t sanity -B bench.cfg.example</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_configuring">Configuring</h3>
+<div class="paragraph">
+<p>Configuration files are usually found in the <code>conf/</code> directory provided with the dsatest package.</p>
+</div>
+<div class="paragraph">
+<p>One can use out-of-tree configuration files by using the <code>-C</code> or <code>--conf-dir</code> flags from the command line.
+The specified directory must have the same layout as the default <code>conf/</code> directory.
+Files found in this alternate directory will have precedence over the default ones.</p>
+</div>
+<div class="paragraph">
+<p>All configuration files use the INI format.
+Three kind of files need to be populated in order to run tests on the bench.
+From a bottom-up approach:</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">switch</dt>
+<dd>
+<p>Describe a switch and how its kernel driver exposes some information.
+This file can be shared and used in several test benches.
+They are located in the <code>switch/</code> configuration directory.</p>
+</dd>
+<dt class="hdlist1">target</dt>
+<dd>
+<p>Describe the machine being tested, the switches that are on it, and the interfaces that the test bench will be able to use.
+This file can also be shared.
+They are located in the <code>target/</code> configuration directory.</p>
+</dd>
+<dt class="hdlist1">bench</dt>
+<dd>
+<p>Describe how the host machine and the target machine are connected to one another.
+This file is specific to each bench.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="_switch_configuration_file">Switch configuration file</h4>
+<div class="paragraph">
+<p>Switch configuration files are located in the <code>switch/</code> subdirectory of the configuration directory.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Switch configuration files have no properties for the moment.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_target_configuration_file">Target configuration file</h4>
+<div class="paragraph">
+<p>Target configuration files are located in the <code>target/</code> subdirectory of the configuration directory.
+They describe the hardware of the machine being tested.</p>
+</div>
+<div class="paragraph">
+<p>It must have one section per switch chip.
+Each indexed switch section must describe the switch model and its enabled links.</p>
+</div>
+<div class="paragraph">
+<p>A target featuring two interconnected switch chips is described as follow:</p>
+</div>
+<div class="listingblock">
+<div class="title">router.cfg</div>
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[switch0] <b class="conum">(1)</b>
+name = "foo-etherswitch" <b class="conum">(2)</b>
+port0 = link0
+port1 = link1
+port2 = link2
+port3 = link3
+
+[switch1]
+name = "foo-etherswitch"
+port0 = link4
+port1 = link5 <b class="conum">(3)</b>
+port2 = link6</code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>Switch section indexed from 0</p>
+</li>
+<li>
+<p>Refers to a <code>foo-etherswitch.cfg</code> switch configuration file</p>
+</li>
+<li>
+<p>Local switch port to global <em>link</em> mapping</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_bench_configuration_file">Bench configuration file</h4>
+<div class="paragraph">
+<p>A bench configuration file describes the test bench, i.e. how the controlling machine (aka host), running dsatest, is connected to the target machine.</p>
+</div>
+<div class="paragraph">
+<p>It must have one section describing the <em>host</em> machine and one section describing the <em>target</em> machine.</p>
+</div>
+<div class="paragraph">
+<p>The purpose of this configuration file is to describe the names of the host and target interfaces connected on both ends of links.</p>
+</div>
+<div class="paragraph">
+<p>An optional <em>control</em> key is used to describe how to access a machine in the form of an URI.
+Several control protocols are available.</p>
+</div>
+<div class="paragraph">
+<p>A bench running tests on a target machine via SSH is described as follow:</p>
+</div>
+<div class="listingblock">
+<div class="title">bench.cfg</div>
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[host] <b class="conum">(1)</b>
+link0 = eth1
+link1 = eth2
+link2 = eth3 <b class="conum">(2)</b>
+link3 = eth4
+
+[target] <b class="conum">(3)</b>
+name = router <b class="conum">(4)</b>
+control = "ssh://target" <b class="conum">(5)</b>
+;username = foo
+;password = bar <b class="conum">(6)</b>
+link0 = lan0
+link1 = lan1
+link2 = lan2 <b class="conum">(7)</b>
+link3 = lan3</code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>Host machine section</p>
+</li>
+<li>
+<p>Interface name of a link on host side</p>
+</li>
+<li>
+<p>Target machine section</p>
+</li>
+<li>
+<p>Refers to a <code>router.cfg</code> target configuration file</p>
+</li>
+<li>
+<p>Control to access the target machine</p>
+</li>
+<li>
+<p>Control specific keys</p>
+</li>
+<li>
+<p>Interface name of a link on target side</p>
+</li>
+</ol>
+</div>
+<div class="sect4">
+<h5 id="_local_control">Local control</h5>
+<div class="paragraph">
+<p>Run command on the local machine. No configuration key is necessary.
+This is the control used by the host machine, which runs the framework.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_ssh_control">SSH control</h5>
+<div class="paragraph">
+<p>Connects to the target machine via SSH.</p>
+</div>
+<div class="paragraph">
+<p>This control requires the <code>ssh://</code> scheme, followed by a hostname and an optional port number.
+There is no mandatory key.
+Optional <em>username</em>, <em>password</em>, <em>keyfile</em> and <em>system_host_keys</em> keys can be used.</p>
+</div>
+<div class="paragraph">
+<p>Here&#8217;s a portion of a <em>target</em> section using the SSH control:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">control = "ssh://localhost"
+username = bob ; <b class="conum">(1)</b>
+password = Secr3t ; <b class="conum">(2)</b>
+keyfile = /home/bob/.ssh/id_rsa ; <b class="conum">(3)</b>
+system_host_keys = /dev/null ; Don't use system host keys <b class="conum">(4)</b></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>Optional username, defaults to "root"</p>
+</li>
+<li>
+<p>Optional password, defaults to empty</p>
+</li>
+<li>
+<p>Optional alternative key file to use</p>
+</li>
+<li>
+<p>Optional alternative host keys file to use</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_telnet_control">Telnet control</h5>
+<div class="paragraph">
+<p>Connects to the target machine via Telnet.</p>
+</div>
+<div class="paragraph">
+<p>This control requires the <code>telnet://</code> scheme, followed by a hostname and an optional port number.
+There is no mandatory key.
+Optional <em>username</em>, <em>password</em>, and <em>prompt</em> keys can be used.</p>
+</div>
+<div class="paragraph">
+<p>Here&#8217;s a portion of a <em>target</em> section using the Telnet control:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">control = "telnet://localhost"
+username = admin ; <b class="conum">(1)</b>
+prompt = "#" ; <b class="conum">(2)</b></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>Optional username to use</p>
+</li>
+<li>
+<p>Optional prompt to use</p>
+</li>
+</ol>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Take a look at the <a href="example.html">example</a> for a complete test bench.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Copy the example bench configuration file and describe your links and how to control your target.
+You may have to provide configuration files for your target and switch(es) if they don&#8217;t exist yet.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sh" data-lang="sh">cp bench.cfg.example bench.cfg
+# edit bench.cfg...</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_running_the_tests">Running the tests</h2>
+<div class="sectionbody">
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+You need the <code>NET_CAP_ADMIN</code> capability in order to configure network interfaces.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Test cases are usually found in the <code>tests/</code> directory provided with the dsatest package.</p>
+</div>
+<div class="paragraph">
+<p>One can use out-of-tree test files by using the <code>-T</code> or <code>--test-dir</code> flags from the command line.
+The specified directory must have the same layout as the default <code>tests/</code> directory.
+Files found in this alternate directory will have precedence over the default ones.</p>
+</div>
+<div class="sect2">
+<h3 id="_from_the_command_line">From the command line</h3>
+<div class="paragraph">
+<p>By default, the <code>dsatest</code> command runs all the tests found in the test directory.
+Run all tests whose method names are prefixed with <strong>test_port_ping</strong>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sh" data-lang="sh">./dsatest -t port_ping</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For details about command line options, see the help message:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sh" data-lang="sh">./dsatest -h</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_from_the_python_api">From the Python API</h3>
+<div class="paragraph">
+<p>Tests are written using unittest, and must respect rules defined by this module.
+They can access the test bench instance through the following import:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-python" data-lang="python">from dsatest.bench import bench</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>API is self-documented in the <code>sanity.py</code> test file.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_authors">Authors</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>dsatest was written by Damien Riegel and other contributors.
+It was inspired by <strong>dsa-tests</strong>, written by Andrew Lunn.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_resources">Resources</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://d-k-c.github.io/dsatest">Project website</a></p>
+</li>
+<li>
+<p><a href="https://github.com/d-k-c/dsatest">Git source repository on GitHub</a></p>
+</li>
+<li>
+<p><a href="dsatest.1.html"><code>dsatest</code> man(ual) page</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2017-10-12 22:20:00 EDT
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR enhances the README, fixes the example, documents the switch, target and bench INI configuration files, adds a manpage (both HTML and Roff formats) and adds a basic website.

In order to do that, a single plain text format is used: AsciiDoc. A Rakefile in a new docs/ directory wraps the calls to [Asciidoctor](http://asciidoctor.org/), the reference processor for AsciiDoc.

The Github Pages in the repository settings must be configured to render the docs/ folder of the master branch.

The website is for the moment a simple HTML rendering of the README file. AsciiDoc preprocessor directives are used to extend the output of the webpage: for the .adoc files directory rendered on Github, use links to other documents, while their content are directly included when rendering HTML. This makes the README file lighter and the website looks more complete, but using the same source file.

Previews are available:
* [README](https://github.com/vivien/dsatest/blob/master/README.adoc)
* [Website](https://vivien.github.io/dsatest/)
* [manpage](https://vivien.github.io/dsatest/dsatest.1.html)

A Roff version of the manpage is also included. `rake` and `asciidoctor` must be installed in order to run `rake` from the docs/ directory and generate manpages and the website.